### PR TITLE
Removed unused `reqwest` dependency, bumped deps, Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,23 +2,22 @@
 name = "iso-rs"
 version = "0.1.4"
 authors = ["Daksh14 <41485688+Daksh14@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 build = "build/build.rs"
 description = "A crate to query ISO data, which includes countries, currencies, etc."
 license = "MIT"
 
 [dependencies]
-phf = "0.8.0"
-chrono = "0.4.19"
-chrono-tz = "0.5.3"
+chrono = "0.4"
+chrono-tz = "0.9"
+phf = "0.11"
 
 [build-dependencies]
+paste = "1.0"
+phf_codegen = "0.11"
+proc-macro2 = "1.0"
 quote = "1.0"
-reqwest = { version = "0.11.3", features = ["blocking"] }
-proc-macro2 = "1.0.26"
-phf_codegen = "0.8.0"
-serde_json = "1.0"
-paste = "1.0.5"
+serde_json = "1"
 
 [features]
 default = ["all"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@
 //! assert_eq!(country.capital.unwrap(), "New Delhi");
 //! ```
 //!
-use chrono_tz::Tz;
+use chrono_tz::{ParseError, Tz};
+
 /// Prelude brings the `Country`, `Currency` and `Language` structs in scope.
 pub mod prelude {
     pub use crate::{Country, Currency, Language};
@@ -169,7 +170,7 @@ impl Country {
 
 impl Timezone {
     /// Get chrono_tz [timezone](https://docs.rs/chrono-tz/0.5.3/chrono_tz/enum.Tz.html)
-    pub fn timezone(&self) -> Result<Tz, String> {
+    pub fn timezone(&self) -> Result<Tz, ParseError> {
         self.iana_identifier.parse()
     }
 }


### PR DESCRIPTION
See subject.

`reqwest` is particuarly problematic. It pulls in `openssl-sys` by default which requires a C compiler to build. See e.g. [here](https://github.com/infobip-community/infobip-api-rust-sdk/pull/25).
TLDR; it's a huge PITA w/o additional feature flags that any crate depending on it should add and forward.

I could not find any use of `reqwest` at all in this crate and neither could `cargo udeps`. So I removed it. I presume it's a leftover?